### PR TITLE
Fix false rollback in Deneva SSI

### DIFF
--- a/contrib/deneva/concurrency_control/row_ssi.cpp
+++ b/contrib/deneva/concurrency_control/row_ssi.cpp
@@ -30,7 +30,7 @@ void Row_ssi::init(row_t * row) {
     pthread_mutex_init(latch, NULL);
     whis_len = 0;
     rhis_len = 0;
-
+    commit_lock = 0;
     preq_len = 0;
 }
 


### PR DESCRIPTION
`commit_lock` is not initialized which causes the high false rollback rate.