### PR TITLE
Add time interval between SQL executions

### DIFF
--- a/src/dbtest/src/common.h
+++ b/src/dbtest/src/common.h
@@ -23,6 +23,7 @@
 #include <vector>
 #include <unordered_map>
 #include <iterator>
+#include <thread>
 
 extern std::string dash;
 extern int blank_base;

--- a/src/dbtest/src/sql_cntl.h
+++ b/src/dbtest/src/sql_cntl.h
@@ -18,6 +18,9 @@ class DBConnector {
 private:
     // Each SQLHDBC is a handle for a single database connection.
     std::vector<SQLHDBC> conn_pool_;
+
+    // Time interval between two sql executions
+    int sql_exec_interval_ = 0;
 public:
     // Initializes the database connector, stablishes a specified number of database connections and adds them to the connection pool.
     bool InitDBConnector(std::string& user, std::string& passwd, std::string& db_type, int conn_pool_size) {
@@ -73,6 +76,8 @@ public:
     bool SetAutoCommit(SQLHDBC m_hDatabaseConnection, int opt);
     // Set a timeout for a specific database connection.
     bool SetTimeout(int conn_id, std::string timeout, const std::string& db_type);
+    // Set the time interval between two SQL executions.
+    void SetSqlExecInterval(int sql_exec_interval) {sql_exec_interval_ = sql_exec_interval;};
 
     // Execute an SQL statement for reading and store the result as an integer.
     bool ExecReadSql2Int(int sql_id, const std::string& sql, TestResultSet& test_result_set, std::unordered_map<int, std::vector<std::string>>& cur_result_set, int conn_id, int param_num, std::string test_process_file="");

--- a/src/dbtest/src/sqltest.cc
+++ b/src/dbtest/src/sqltest.cc
@@ -24,6 +24,7 @@ DEFINE_int32(conn_pool_size, 6, "db_conn pool size");
 DEFINE_string(isolation, "serializable", "transation isolation level: read-uncommitted read-committed repeatable-read serializable");
 DEFINE_string(case_dir, "mysql", "test case dir name");
 DEFINE_string(timeout, "20", "timeout");
+DEFINE_int32(sql_interval, 0, "interval time between sql executions");
 
 // std::vector<std::mutex *> mutex_txn(5); // same as conn_pool_size
 std::vector<pthread_mutex_t *> mutex_txn(FLAGS_conn_pool_size);  // same as conn_pool_size
@@ -416,6 +417,7 @@ int main(int argc, char* argv[]) {
     std::cout << "  user: " + FLAGS_user << std::endl;
     std::cout << "  passwd: " + FLAGS_passwd << std::endl;
     std::cout << "  isolation: " + FLAGS_isolation << std::endl;
+    std::cout << "  sql interval: " + std::to_string(FLAGS_sql_interval) << std::endl;
 
     // mutex for txn
     for(int i=0;i<FLAGS_conn_pool_size;++i) {
@@ -526,6 +528,8 @@ int main(int argc, char* argv[]) {
         if (!db_connector.InitDBConnector(FLAGS_user, FLAGS_passwd, FLAGS_db_type, FLAGS_conn_pool_size)) {
             std::cout << "init db_connector failed" << std::endl;
         }
+        // set sql interval
+        db_connector.SetSqlExecInterval(FLAGS_sql_interval);
         // set TXN_ISOLATION
         // crdb has only one isolation level, which is serializable by default
         if (FLAGS_db_type != "crdb" && FLAGS_db_type != "mongodb" && FLAGS_db_type != "yugabyte") {

--- a/src/dbtest/src/sqltest_v2.cc
+++ b/src/dbtest/src/sqltest_v2.cc
@@ -24,6 +24,7 @@ DEFINE_int32(conn_pool_size, 30, "db_conn pool size");
 DEFINE_string(isolation, "serializable", "transation isolation level: read-uncommitted read-committed repeatable-read serializable");
 DEFINE_string(case_dir, "mysql", "test case dir name");
 DEFINE_string(timeout, "3", "timeout");
+DEFINE_int32(sql_interval, 0, "interval time between sql executions");
 
 
 std::vector<pthread_mutex_t *> mutex_txn(FLAGS_conn_pool_size);  // same as conn_pool_size
@@ -373,6 +374,7 @@ int main(int argc, char* argv[]) {
     std::cout << "  user: " + FLAGS_user << std::endl;
     std::cout << "  passwd: " + FLAGS_passwd << std::endl;
     std::cout << "  isolation: " + FLAGS_isolation << std::endl;
+    std::cout << "  sql interval: " + std::to_string(FLAGS_sql_interval) << std::endl;
 
     // mutex for txn
     for(int i=0;i<FLAGS_conn_pool_size;++i) {
@@ -476,6 +478,8 @@ int main(int argc, char* argv[]) {
         if (!db_connector.InitDBConnector(FLAGS_user, FLAGS_passwd, FLAGS_db_type, FLAGS_conn_pool_size)) {
             std::cout << "init db_connector failed" << std::endl;
         }
+        // set sql interval
+        db_connector.SetSqlExecInterval(FLAGS_sql_interval);
         // set TXN_ISOLATION
         // crdb has only one isolation level, which is serializable by default
         if (FLAGS_db_type != "crdb" && FLAGS_db_type != "mongodb") {


### PR DESCRIPTION
1. Add input parameter "time interval" to pause between every two SQL executions.
2. The execution interval is displayed when an SQL is successfully executed
3. The precision of the time interval is in milliseconds and the default value is 0