### PR TITLE
Add integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: 3TS CI
+
+on:
+  push:
+    branches:
+      - coo-consistency-check
+  pull_request:
+    branches:
+      - coo-consistency-check
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    # 设置构建环境和安装依赖项
+    - name: Set up build environment
+      run: |
+        echo "Setting up build environment..."
+        sudo apt-get update && sudo apt-get install -y cmake make g++ libgflags-dev unixodbc unixodbc-dev odbcinst odbcinst1debian2
+        echo "Build environment setup complete."
+
+    # 安装 Docker，如果尚未安装
+    - name: Install Docker
+      run: |
+        echo "Installing Docker..."
+        curl -s https://get.docker.com/ | sh
+        echo "Docker installed successfully."
+
+    # 拉取 Docker 镜像
+    - name: Pull Docker image
+      run: docker pull registry.cn-hangzhou.aliyuncs.com/open_projects/3ts_coo:1.0
+
+    # 列出 Docker 镜像
+    - name: List Docker images
+      run: docker images
+
+    # 运行 Docker 容器，并挂载项目目录
+    - name: Run Docker container with volume
+      run: |
+        IMAGE_ID=$(docker images -q registry.cn-hangzhou.aliyuncs.com/open_projects/3ts_coo:1.0)
+        docker run -d --name 3ts_container -v ${{ github.workspace }}:/src $IMAGE_ID tail -f /dev/null
+
+    # 在 Docker 容器中编译
+    - name: Compile inside Docker
+      run: |
+        echo "Compiling in Docker container..."
+        docker exec -i 3ts_container bash -c "cd /src/src/dbtest && cmake -S ./ && make"
+
+    # 清理 Docker 容器
+    - name: Clean up Docker container
+      if: always()
+      run: docker rm -f 3ts_container
+
+    # 在非 Docker 环境中编译
+    - name: Compile without Docker
+      run: |
+        echo "Compiling using CMake..."
+        cd src/dbtest
+        sudo rm -rf CMakeCache.txt CMakeFiles  # 清除缓存文件
+        cmake -S ./ || cmake -DCMAKE_PREFIX_PATH=/usr/ -S ./
+        make
+        echo "Compilation finished."

--- a/src/dbtest/CMakeLists.txt
+++ b/src/dbtest/CMakeLists.txt
@@ -17,7 +17,26 @@ list(APPEND THIRD_PARTIES pthread)
 
 find_package(gflags REQUIRED)
 list(APPEND THIRD_PARTIES gflags)
+#
+# Manually find ODBC library and headers
+find_path(ODBC_INCLUDE_DIR sql.h
+  PATHS /usr/include /usr/local/include
+)
 
+find_library(ODBC_LIBRARIES
+  NAMES odbc odbc32
+  PATHS /usr/lib /usr/local/lib
+)
+
+# Check if ODBC was found
+if (ODBC_INCLUDE_DIR AND ODBC_LIBRARIES)
+  message(STATUS "Found ODBC library and include directory.")
+  include_directories(${ODBC_INCLUDE_DIR})
+  list(APPEND ODBC_LD ${ODBC_LIBRARIES})
+else()
+  message(FATAL_ERROR "Could not find ODBC library or include directory.")
+endif()
+#
 ########### sql test V1 #############
 # static test with 33 test case
 # all .cc files
@@ -30,9 +49,9 @@ list(APPEND SOURCE_FILES_SQL
 # bin
 add_executable(3ts_dbtest ${SOURCE_FILES_SQL})
 # ld:odbc
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/Modules/")
-find_package(ODBC REQUIRED)
-list(APPEND ODBC_LD odbc)
+#list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/Modules/")
+#find_package(ODBC REQUIRED)
+#list(APPEND ODBC_LD odbc)
 # link ld
 target_link_libraries(3ts_dbtest ${THIRD_PARTIES})
 target_link_libraries(3ts_dbtest ${ODBC_LD})
@@ -49,9 +68,9 @@ list(APPEND SOURCE_FILES_SQL_v2
 # bin
 add_executable(3ts_dbtest_v2 ${SOURCE_FILES_SQL_v2})
 # ld:odbc
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/Modules/")
-find_package(ODBC REQUIRED)
-list(APPEND ODBC_LD odbc)
+#list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/Modules/")
+#find_package(ODBC REQUIRED)
+#list(APPEND ODBC_LD odbc)
 # link ld
 target_link_libraries(3ts_dbtest_v2 ${THIRD_PARTIES})
 target_link_libraries(3ts_dbtest_v2 ${ODBC_LD})


### PR DESCRIPTION
hi I have added integration tests and modified the CMakeLists.txt.

I believe a good project requires integration testing to ensure that contributors do not compromise the stability of the project. The integration test currently only checks whether the container and local compilation succeed. It does not test the installed PostgreSQL database inside the container. If needed, please let me know (we may need to add a configuration file in the repository and write a script to automatically create a user in PostgreSQL).

The results can be seen in the pull request record under the pr branch of my repository.
Result:
![image](https://github.com/user-attachments/assets/17ed77de-7714-473b-bf50-7c7004eab87b)

![image](https://github.com/user-attachments/assets/ff075da5-ba8c-4c17-8925-49e02f3b5252)
